### PR TITLE
Basisarray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 AffineRayleighOptimization = "2"
 OrderedCollections = "1.6.3"
 julia = "1.10"
+QuantumDots = "0.12"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 AffineRayleighOptimization = "2"
 OrderedCollections = "1.6.3"
 julia = "1.10"
-QuantumDots = "0.12"
+QuantumDots = "0.13.1"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/Majoranas.jl
+++ b/src/Majoranas.jl
@@ -18,8 +18,8 @@ include("weak_majorana_utils.jl")
 include("weak_majorana_constraints.jl")
 include("weak_majorana_problem.jl")
 include("majorana_polarization.jl")
-include("basisarray.jl")
 include("majorana_metrics.jl")
+include("basisarray.jl")
 
 export SingleParticleMajoranaBasis, ManyBodyMajoranaBasis, HamiltonianBasis, ProjectedHamiltonianBasis, labels, coeffs_to_dict
 export WeakMajoranaProblem

--- a/src/Majoranas.jl
+++ b/src/Majoranas.jl
@@ -17,6 +17,7 @@ include("weak_majorana_utils.jl")
 include("weak_majorana_constraints.jl")
 include("weak_majorana_problem.jl")
 include("majorana_polarization.jl")
+include("basisarray.jl")
 
 export SingleParticleMajoranaBasis, ManyBodyMajoranaBasis, HamiltonianBasis, ProjectedHamiltonianBasis, labels, coeffs_to_dict
 export WeakMajoranaProblem

--- a/src/basisarray.jl
+++ b/src/basisarray.jl
@@ -80,8 +80,6 @@ Base.:*(x::BasisArray, y::Number) = BasisArray(x.parent .* y, x.basis)
 Base.:*(x::Number, y::BasisArray) = BasisArray(x .* y.parent, y.basis)
 
 # addition
-# MatrixTypes = Union{<:UniformScaling,<:Matrix,<:SparseArrays.SparseMatrixCSC}
-# VecTypes = Union{UniformScaling,Array,SparseMatrixCSC,SparseVector}
 Base.:+(x::BMatrix, y::UniformScaling) = BasisArray(x.parent + y, x.basis)
 Base.:+(x::UniformScaling, y::BMatrix) = BasisArray(x + y.parent, y.basis)
 Base.:+(x::BasisArray, y::Array) = BasisArray(x.parent + y, x.basis)
@@ -146,10 +144,6 @@ Base.eltype(b::ManyBodyBasisArrayWrapper) = eltype(b.basis)
 Base.keytype(b::ManyBodyBasisArrayWrapper) = keytype(b.basis)
 BasisArray(m::AbstractArray, b::ManyBodyBasisArrayWrapper) = BasisArray(m, b.basis)
 
-# function basisarrays(b::FermionBasis{M,D,S}) where {M,D,S}
-#     newdict = QuantumDots.OrderedCollections.OrderedDict([k => BasisArray(v, b) for (k, v) in pairs(b.dict)])
-#     b = FermionBasis{M,typeof(newdict),S}(newdict, b.symmetry)
-# end
 
 @testitem "BasisArray" begin
     using Majoranas: BasisArray, ManyBodyBasisArrayWrapper

--- a/src/basisarray.jl
+++ b/src/basisarray.jl
@@ -152,7 +152,7 @@ BasisArray(m::AbstractArray, b::ManyBodyBasisArrayWrapper) = BasisArray(m, b.bas
 # end
 
 @testitem "BasisArray" begin
-    using Majoranas: BasisArray, basisarrays, ManyBodyBasisArrayWrapper
+    using Majoranas: BasisArray, ManyBodyBasisArrayWrapper
     using QuantumDots, LinearAlgebra
     qn = ParityConservation()
     c1 = FermionBasis(1:1; qn) |> ManyBodyBasisArrayWrapper

--- a/src/basisarray.jl
+++ b/src/basisarray.jl
@@ -108,7 +108,6 @@ Base.transpose(b::BasisArray) = BasisArray(transpose(b.parent), b.basis)
 Base.zero(x::BasisArray) = BasisArray(zero(x.parent), x.basis)
 Base.one(x::BasisArray) = BasisArray(one(x.parent), x.basis)
 
-QuantumDots.wedge(bs::AbstractVector{<:BasisArray}, b::ManyBodyBasisArrayWrapper) = wedge(bs, b.basis)
 QuantumDots.wedge(bs::AbstractVector{<:BasisArray}, b::FermionBasis) = BasisArray(wedge(map(b -> b.parent, bs), map(b -> b.basis, bs), b), b)
 QuantumDots.blockdiagonal(b::BasisArray) = BasisArray(blockdiagonal(b.parent, b.basis), b.basis)
 QuantumDots.partial_trace(m::Union{BMatrix,BVector}, bsub::QuantumDots.AbstractBasis) = BasisArray(partial_trace(m.parent, bsub, m.basis), bsub)
@@ -143,7 +142,7 @@ QuantumDots.nbr_of_fermions(b::ManyBodyBasisArrayWrapper) = nbr_of_fermions(b.ba
 Base.eltype(b::ManyBodyBasisArrayWrapper) = eltype(b.basis)
 Base.keytype(b::ManyBodyBasisArrayWrapper) = keytype(b.basis)
 BasisArray(m::AbstractArray, b::ManyBodyBasisArrayWrapper) = BasisArray(m, b.basis)
-
+QuantumDots.wedge(bs::AbstractVector{<:BasisArray}, b::ManyBodyBasisArrayWrapper) = wedge(bs, b.basis)
 
 @testitem "BasisArray" begin
     using Majoranas: BasisArray, ManyBodyBasisArrayWrapper

--- a/src/basisarray.jl
+++ b/src/basisarray.jl
@@ -1,0 +1,129 @@
+
+using Base: @propagate_inbounds
+
+struct BasisArray{T,N,A,B} <: AbstractArray{T,N}
+    parent::A
+    basis::B
+    function BasisArray(parent::AbstractArray{T,N}, basis::B) where {T,N,B}
+        new{T,N,typeof(parent),B}(parent, basis)
+    end
+end
+
+BasisArray{T}(parent::AbstractArray{T,N}, basis) where {T,N} = BasisArray(parent, basis)
+
+BasisArray{T,N}(parent::AbstractArray{T,N}, basis) where {T,N} = BasisArray(parent, basis)
+
+BasisArray{T,N,P}(parent::P, basis) where {T,N,P<:AbstractArray{T,N}} = BasisArray(parent, basis)
+
+#--------------------------------------
+# aliases
+
+const BVector{T,P} = BasisArray{T,1,P}
+
+BVector(parent::AbstractVector, basis) = BasisArray(parent, basis)
+
+const BMatrix{T,P} = BasisArray{T,2,P}
+
+BMatrix(parent::AbstractMatrix, basis) = BasisArray(parent, basis)
+
+#--------------------------------------
+# https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-parentay
+
+Base.size(x::BasisArray, args...) = size(x.parent, args...)
+
+@propagate_inbounds function Base.getindex(x::BasisArray, args...)
+    getindex(x.parent, args...)
+end
+Base.setindex!(x::BasisArray, args...) = setindex!(x.parent, args...)
+
+Base.IndexStyle(::Type{<:BasisArray{T,N,P}}) where {T,N,P} = IndexStyle(P)
+
+Base.iterate(x::BasisArray, args...) = iterate(x.parent, args...)
+
+Base.length(x::BasisArray) = length(x.parent)
+
+Base.similar(x::BasisArray) = BasisArray(similar(x.parent), x.basis)
+Base.similar(x::BasisArray, dims::Union{Integer,AbstractUnitRange}...) = BasisArray(similar(x.parent, dims...), x.basis)
+Base.similar(x::BasisArray, ::Type{T}, dims::Union{Integer,AbstractUnitRange}...) where {T} = BasisArray(similar(x.parent, T, dims...), x.basis)
+
+Base.axes(x::BasisArray) = axes(x.parent)
+
+function Base.IteratorSize(::Type{<:BasisArray{T,N,P}}) where {T,N,P}
+    Base.IteratorSize(P)
+end
+
+function Base.IteratorEltype(::Type{<:BasisArray{T,N,P}}) where {T,N,P}
+    Base.IteratorEltype(P)
+end
+
+function Base.eltype(::Type{<:BasisArray{T,N,P}}) where {T,N,P}
+    eltype(P)
+end
+
+Base.firstindex(x::BasisArray) = firstindex(x.parent)
+
+Base.lastindex(x::BasisArray) = lastindex(x.parent)
+
+Base.strides(x::BasisArray) = strides(x.parent)
+
+function Base.unsafe_convert(p::Type{Ptr{T}}, x::BasisArray) where {T}
+    Base.unsafe_convert(p, x.parent)
+end
+
+Base.stride(x::BasisArray, i::Int) = stride(x.parent, i)
+
+Base.parent(x::BasisArray) = x.parent
+
+function Base.convert(::Type{BasisArray{T,N}}, mutable_parent::AbstractArray{T,N}) where {T,N}
+    BasisArray(mutable_parent)
+end
+
+# multiplication
+# Base.:*(x::BasisArray, y::AbstractArray) = BasisArray(x.parent .* y, x.basis)
+# Base.:*(x::AbstractArray, y::BasisArray) = BasisArray(x .* y.parent, y.basis)
+Base.:*(x::BasisArray, y::BasisArray) = x.basis == y.basis ? BasisArray(x.parent * y.parent, x.basis) : throw(ArgumentError("Basis mismatch"))
+Base.:*(x::BasisArray, y::Number) = BasisArray(x.parent .* y, x.basis)
+Base.:*(x::Number, y::BasisArray) = BasisArray(x .* y.parent, y.basis)
+
+# addition
+Base.:+(x::BasisArray, y::UniformScaling) = BasisArray(x.parent + y, x.basis)
+Base.:+(x::UniformScaling, y::BasisArray) = BasisArray(x + y.parent, y.basis)
+Base.:+(x::BasisArray, y::BasisArray) = x.basis == y.basis ? BasisArray(x.parent + y.parent, x.basis) : throw(ArgumentError("Basis mismatch"))
+Base.:+(x::BasisArray, y::Number) = BasisArray(x.parent + y, x.basis)
+Base.:+(x::Number, y::BasisArray) = BasisArray(x + y.parent, y.basis)
+
+# subtraction
+Base.:-(x::BasisArray, y::UniformScaling) = BasisArray(x.parent - y, x.basis)
+Base.:-(x::UniformScaling, y::BasisArray) = BasisArray(x - y.parent, y.basis)
+Base.:-(x::BasisArray, y::BasisArray) = x.basis == y.basis ? BasisArray(x.parent - y.parent, x.basis) : throw(ArgumentError("Basis mismatch"))
+Base.:-(x::BasisArray) = BasisArray(-x.parent, x.basis)
+Base.:-(x::BasisArray, y::Number) = BasisArray(x.parent - y, x.basis)
+Base.:-(x::Number, y::BasisArray) = BasisArray(x - y.parent, y.basis)
+
+QuantumDots.diagonalize(b::BasisArray) = BasisArray(diagonalize(b.parent), b.basis)
+
+QuantumDots.wedge(bs::AbstractVector{<:BasisArray}, b::FermionBasis) = wedge(map(b -> b.parent, bs), map(b -> b.basis, bs), b)
+
+Base.adjoint(b::BasisArray) = BasisArray(adjoint(b.parent), b.basis)
+Base.transpose(b::BasisArray) = BasisArray(transpose(b.parent), b.basis)
+Base.zero(x::BasisArray) = BasisArray(zero(x.parent), x.basis)
+Base.one(x::BasisArray) = BasisArray(one(x.parent), x.basis)
+
+@testitem "BasisArray" begin
+    using Majoranas: BasisArray
+    using QuantumDots, LinearAlgebra
+    c1 = FermionBasis(1:1)
+    c2 = FermionBasis(2:2)
+    c12 = FermionBasis(1:2)
+    v = BasisArray(rand(2), c1)
+    f1 = BasisArray(c1[1], c1)
+    @test f1 * v isa BasisArray
+    @test f1 + c1[1] == 2 * f1
+    @test f1 == f1
+    @test iszero(f1 - f1)
+    @test (f1 * I * f1' * I) * 2 + 2I + f1 - 5 * f1 isa BasisArray
+
+    f2 = BasisArray(c2[2], c2)
+    @test wedge([f1, f2], c12) isa BasisArray
+    @test wedge([f1, f2], c12) == c12[1] * c12[2]
+end


### PR DESCRIPTION
See issue #25.
Might be ready to be tested more in some workloads. Problems that might arise are ambiguities when mixing BasisArrays with other types of arrays, the basis information disappearing, and poor performance because one might get dispatched to some generic function using getindex instead of an optimized one based on the parent array.